### PR TITLE
Possibility to generate clean DC dataset using PowerGrid Solver

### DIFF
--- a/configurations/powergrid/benchmarks/l2rpn_case14_sandbox.ini
+++ b/configurations/powergrid/benchmarks/l2rpn_case14_sandbox.ini
@@ -194,6 +194,90 @@ eval_params = {
 			"verify_reactive_power": True},
 	}
 
+[Benchmark4]
+attr_x = ("prod_p", "load_p")
+attr_tau = ("line_status", "topo_vect")
+attr_y = ("theta_or", "theta_ex", "p_or", "p_ex")
+attr_physics = ("YBus", "SBus", "PV_nodes", "slack")
+dataset_create_params = {
+	"train": {
+		# SCENARIO TOPOLOGY : disconnect or not one line at each tim step
+		"prob_depth": (1.,), # sample from depth 1
+		"prob_type": (0., 1.), # sample only from line disconnection
+		"prob_do_nothing": 0.3,  # probability of do nothing
+		"max_disc": 1}, # authorize at most 1 disconnection
+	"test":{
+		# SCENARIO TOPOLOGY: disconnect one line at each time step
+		"prob_depth": (1.,), # sample from depth 1
+		"prob_type": (0., 1.), # sample only from line disconnection
+		"prob_do_nothing": 0.,  # No do nothing
+		"max_disc": 1}, # authorize at most 1 disconnection
+	"test_ood":{
+		# SCENARIO TOPOLOGY: disconnect two lines at each time step
+		"prob_depth": (0., 1.), # Sample only from depth 2
+		"prob_type": (0., 1.), # sample only from line disconnection
+		"prob_do_nothing": 0.,  # No do nothing
+		"max_disc": 2} # authorize at most 2 disconnection
+	}
+
+eval_dict = {
+	"ML": ["MSE_avg", "MAE_avg", "MAPE_avg", "MAPE_90_avg", "TIME_INF"],
+	"Physics": ["CURRENT_POS"],
+	"IndRed": ["TIME_INF"],
+	"OOD": ["MSE_avg", "MAE_avg", "MAPE_avg", "MAPE_90_avg", "TIME_INF"]}
+
+eval_params = {
+	"inf_batch_size": 14000} # #pas_de_temps=100 x #ligne=20 x #topo=7
+
+# same as benchmark4 with reference actions
+[Benchmark5]
+attr_x = ("prod_p", "load_p")
+attr_tau = ("line_status", "topo_vect")
+attr_y = ("theta_or", "theta_ex", "p_or", "p_ex")
+attr_physics = ("YBus", "SBus", "PV_nodes", "slack")
+dataset_create_params = {
+	# REFERENCE PARAMS
+	"reference_args" : {
+		# "lines_to_disc": [3],
+		# "subs_to_change": [(1,13), (3,8), (4, 3), (8,6)], # (sub_id, action_id)
+		"topo_actions": [
+				{'set_bus':{'substations_id':[(4,(2,1,2,1,2))]}},#sub4
+ 				{'set_bus':{'substations_id':[(1,(1,2,1,2,2,2))]}},#sub1
+				{'set_bus':{'substations_id':[(5,(1,1,2,2,1,2,2))]}}#sub5
+			],
+		"prob_depth": (0.7, 0.3), # authorizing until depth 2 combinations for reference
+		"prob_type": (1., 0.), # only topology change actions
+		"prob_do_nothing": 0.2, # include 20 percent DoNothing actions
+		"max_disc": 0},#no line disconnections
+	"train": {
+		# SCENARIO TOPOLOGY : disconnect or not one line at each tim step
+		"prob_depth": (1.,), # sample from depth 1
+		"prob_type": (0., 1.), # sample only from line disconnection
+		"prob_do_nothing": 0.3,  # probability of do nothing
+		"max_disc": 1}, # authorize at most 1 disconnection
+	"test":{
+		# SCENARIO TOPOLOGY: disconnect one line at each time step
+		"prob_depth": (1.,), # sample from depth 1
+		"prob_type": (0., 1.), # sample only from line disconnection
+		"prob_do_nothing": 0.,  # No do nothing
+		"max_disc": 1}, # authorize at most 1 disconnection
+	"test_ood":{
+		# SCENARIO TOPOLOGY: disconnect two lines at each time step
+		"prob_depth": (0., 1.), # Sample only from depth 2
+		"prob_type": (0., 1.), # sample only from line disconnection
+		"prob_do_nothing": 0.,  # No do nothing
+		"max_disc": 2} # authorize at most 2 disconnection
+	}
+
+eval_dict = {
+	"ML": ["MSE_avg", "MAE_avg", "MAPE_avg", "MAPE_90_avg", "TIME_INF"],
+	"Physics": ["CURRENT_POS"],
+	"IndRed": ["TIME_INF"],
+	"OOD": ["MSE_avg", "MAE_avg", "MAPE_avg", "MAPE_90_avg", "TIME_INF"]}
+
+eval_params = {
+	"inf_batch_size": 14000} # #pas_de_temps=100 x #ligne=20 x #topo=7
+
 [DoNothing]
 attr_x = ("prod_p", "prod_v", "load_p", "load_q")
 attr_tau = ("line_status", "topo_vect")

--- a/getting_started/PowerGridUsecase/auxiliary/Generate_with_DC.ipynb
+++ b/getting_started/PowerGridUsecase/auxiliary/Generate_with_DC.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "import pathlib\n",
     "\n",
-    "LIPS_PATH = pathlib.Path().resolve().parent.parent\n",
+    "LIPS_PATH = pathlib.Path().resolve().parent.parent.parent\n",
     "CONFIG_PATH = LIPS_PATH / \"configurations\" / \"powergrid\" / \"benchmarks\" / \"l2rpn_case14_sandbox.ini\"\n",
     "DATA_PATH = LIPS_PATH / \"reference_data\" / \"powergrid\" / \"l2rpn_case14_sandbox\" / \"DC\"\n",
     "LOG_PATH = LIPS_PATH / \"lips_logs.log\""
@@ -35,14 +35,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "from lips.benchmark.powergridBenchmark import PowerGridBenchmark\n",
     "\n",
-    "benchmark4 = PowerGridBenchmark(benchmark_path=DATA_PATH,\n",
-    "                                benchmark_name=\"Benchmark4\",\n",
+    "benchmark5 = PowerGridBenchmark(benchmark_path=DATA_PATH,\n",
+    "                                benchmark_name=\"Benchmark5\",\n",
     "                                load_data_set=False,\n",
     "                                config_path=CONFIG_PATH,\n",
     "                                log_path=LOG_PATH)"
@@ -50,22 +50,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 100000/100000 [06:34<00:00, 253.34it/s]\n",
-      "100%|██████████| 10000/10000 [00:52<00:00, 189.51it/s]\n",
-      "100%|██████████| 10000/10000 [00:52<00:00, 190.63it/s]\n",
-      "100%|██████████| 10000/10000 [01:07<00:00, 147.76it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "benchmark4.generate(nb_sample_train=int(1e5),\n",
+    "benchmark5.generate(nb_sample_train=int(1e5),\n",
     "                    nb_sample_val=int(1e4),\n",
     "                    nb_sample_test=int(1e4),\n",
     "                    nb_sample_test_ood_topo=int(1e4),\n",
@@ -76,24 +65,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[19 20 19 ... 20 20 19]\n",
-      "[19 19 19 ... 19 19 19]\n",
-      "[18 18 18 ... 18 18 18]\n"
+      "[19 20 19 19 20 19 19 19 20 20]\n",
+      "[19 19 19 19 19 19 19 19 19 19]\n",
+      "[19 19 19 19 19 19 19 19 19 19]\n",
+      "[18 18 18 18 18 18 18 18 18 18]\n"
      ]
     }
    ],
    "source": [
     "import numpy as np\n",
-    "print(np.sum(benchmark4.train_dataset.data[\"line_status\"], axis=1))\n",
-    "print(np.sum(benchmark4._test_dataset.data[\"line_status\"], axis=1))\n",
-    "print(np.sum(benchmark4._test_ood_topo_dataset.data[\"line_status\"], axis=1))"
+    "print(np.sum(benchmark5.train_dataset.data[\"line_status\"], axis=1)[:10])\n",
+    "print(np.sum(benchmark5.val_dataset.data[\"line_status\"], axis=1)[:10])\n",
+    "print(np.sum(benchmark5._test_dataset.data[\"line_status\"], axis=1)[:10])\n",
+    "print(np.sum(benchmark5._test_ood_topo_dataset.data[\"line_status\"], axis=1)[:10])"
    ]
   },
   {

--- a/lips/physical_simulator/grid2opSimulator.py
+++ b/lips/physical_simulator/grid2opSimulator.py
@@ -159,6 +159,10 @@ class Grid2opSimulator(PhysicalSimulator):
             if check:
                 done=True
 
+            check = self.__any_nan_values(self._obs)
+            if check:
+                done=True
+
             self._time_powerflow += _diff_time_pf
             self.comp_time += _diff_time_cp
 
@@ -275,6 +279,19 @@ class Grid2opSimulator(PhysicalSimulator):
         #    print("There are some isolated injections")
         return check_all
 
+    def __any_nan_values(self, obs):
+        """Verify if there are any nan values during data generation
+
+        Parameters
+        ----------
+        obs : _type_
+            _description_
+        """
+        check = False
+        if any(np.isnan(obs.p_or)):
+            check = True
+        return check
+    
 def get_env(env_kwargs: dict):
     """Getter for the environment
 


### PR DESCRIPTION
- Some verification are added to exclude the NaN values when generating data using DC solver. 
- The configuration file updated for IEEE14 to include two configurations which are used mainly by Graph Neural Networks to model power grid dynamics